### PR TITLE
Fix Apaleo OAuth Links

### DIFF
--- a/src/views/index.pug
+++ b/src/views/index.pug
@@ -2,8 +2,8 @@ extends layout.pug
 
 block content
     .btn-container
-        a.btn-primary(href="https://identity.apaleo.com/connect/authorize?response_type=code&scope=openid profile&client_id=FSXN-AC-PAYJIM&redirect_uri=https://apaleo-oauth-example.onrender.com/auth/apaleo/redirect&state=register 23371848-524f-40e5-bdf1-c0a8d6c2fc1d") Register Using Apaleo
-        a.btn-primary(href="https://identity.apaleo.com/connect/authorize?response_type=code&scope=offline_access folios.manage folios.payment-with-charges folios.read invoices.read invoices.manage openid profile setup.read reservations.read reservations.manage&client_id=FSXN-AC-PAYJIM&redirect_uri=https://apaleo-oauth-example.onrender.com/auth/apaleo/redirect&state=login 23371848-524f-40e5-bdf1-c0a8d6c2fc1d") Log in Using Apaleo
+        a.btn-primary(href="https://identity.apaleo.com/connect/authorize?response_type=code&scope=openid profile&client_id=KCZM-AC-PAYJIM&redirect_uri=https://apaleo-oauth-example.onrender.com/auth/apaleo/redirect&state=23371848-524f-40e5-bdf1-c0a8d6c2fc1d") Register Using Apaleo
+        a.btn-primary(href="https://identity.apaleo.com/connect/authorize?response_type=code&scope=offline_access folios.manage folios.payment-with-charges folios.read invoices.read invoices.manage openid profile setup.read reservations.read reservations.manage&client_id=KCZM-AC-PAYJIM&redirect_uri=https://apaleo-oauth-example.onrender.com/auth/apaleo/redirect&state=23371848-524f-40e5-bdf1-c0a8d6c2fc1d") Log in Using Apaleo
 
 block messages
     p No messages


### PR DESCRIPTION
This PR fixes the OAuth Apaleo links of the "Register" and "Login" buttons. The **redirect_uri** passed as a query string parameter to identity.apaleo should be the same as the one saved in the dashboard.